### PR TITLE
feat: add CRUD routes and handlers for Item entity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "@hapi/hapi": "^21.3.10",
-        "@prisma/client": "^6.12.0"
+        "@prisma/client": "^6.12.0",
+        "joi": "^17.13.3"
       },
       "devDependencies": {
         "@swc/core": "^1.7.2",
@@ -1448,6 +1449,33 @@
       "dependencies": {
         "@prisma/debug": "6.12.0"
       }
+    },
+    "node_modules/@sideway/address": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@sideway/address/node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@sideway/formula": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -3640,6 +3668,34 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/joi": {
+      "version": "17.13.3",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
+      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^9.3.0",
+        "@hapi/topo": "^5.1.0",
+        "@sideway/address": "^4.1.5",
+        "@sideway/formula": "^3.0.1",
+        "@sideway/pinpoint": "^2.0.0"
+      }
+    },
+    "node_modules/joi/node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/joi/node_modules/@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@hapi/hapi": "^21.3.10",
-    "@prisma/client": "^6.12.0"
+    "@prisma/client": "^6.12.0",
+    "joi": "^17.13.3"
   }
 }

--- a/src/item.handlers.ts
+++ b/src/item.handlers.ts
@@ -26,3 +26,13 @@ export const updateItem = async (request: Request, h: ResponseToolkit) => {
         return h.response({ error: 'Item not found' }).code(404);
     }
 };
+
+export const deleteItem = async (request: Request, h: ResponseToolkit) => {
+    const id = parseInt(request.params.id);
+    try {
+        await ItemService.deleteItem(id);
+        return h.response().code(204);
+    } catch {
+        return h.response({ error: 'Item not found' }).code(404);
+    }
+};

--- a/src/item.handlers.ts
+++ b/src/item.handlers.ts
@@ -16,3 +16,13 @@ export const createItem = async (request: Request, h: ResponseToolkit) => {
     const item = await ItemService.createItem({ name, price });
     return h.response(item).code(201);
 };
+
+export const updateItem = async (request: Request, h: ResponseToolkit) => {
+    const id = parseInt(request.params.id);
+    const { name, price } = request.payload as any;
+    try {
+        return await ItemService.updateItem(id, { name, price });
+    } catch {
+        return h.response({ error: 'Item not found' }).code(404);
+    }
+};

--- a/src/item.handlers.ts
+++ b/src/item.handlers.ts
@@ -1,5 +1,12 @@
+import { Request, ResponseToolkit } from '@hapi/hapi';
 import * as ItemService from './item.service';
 
 export const getItems = async () => {
     return await ItemService.getItems();
+};
+
+export const getItemById = async (request: Request, h: ResponseToolkit) => {
+    const id = parseInt(request.params.id);
+    const item = await ItemService.getItemById(id);
+    return item ?? h.response({ error: 'Item not found' }).code(404);
 };

--- a/src/item.handlers.ts
+++ b/src/item.handlers.ts
@@ -10,3 +10,9 @@ export const getItemById = async (request: Request, h: ResponseToolkit) => {
     const item = await ItemService.getItemById(id);
     return item ?? h.response({ error: 'Item not found' }).code(404);
 };
+
+export const createItem = async (request: Request, h: ResponseToolkit) => {
+    const { name, price } = request.payload as any;
+    const item = await ItemService.createItem({ name, price });
+    return h.response(item).code(201);
+};

--- a/src/item.handlers.ts
+++ b/src/item.handlers.ts
@@ -1,0 +1,5 @@
+import * as ItemService from './item.service';
+
+export const getItems = async () => {
+    return await ItemService.getItems();
+};

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -37,4 +37,24 @@ export const defineRoutes = (server: Server) => {
         },
         handler: Handlers.getItemById,
     });
+
+    server.route({
+        method: 'POST',
+        path: '/items',
+        options: {
+            validate: {
+                payload: Joi.object({
+                    name: Joi.string().min(1).required(),
+                    price: Joi.number().positive().required(),
+                }),
+                failAction: (request, h, err) => {
+                    return h
+                        .response({ error: err?.message ?? 'Invalid request' })
+                        .code(400)
+                        .takeover();
+                },
+            },
+        },
+        handler: Handlers.createItem,
+    });
 };

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,4 +1,5 @@
 import { Server } from '@hapi/hapi';
+import * as Handlers from './item.handlers';
 
 export const defineRoutes = (server: Server) => {
     server.route({
@@ -9,5 +10,11 @@ export const defineRoutes = (server: Server) => {
                 ok: true,
             };
         },
+    });
+
+    server.route({
+        method: 'GET',
+        path: '/items',
+        handler: Handlers.getItems,
     });
 };

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,5 +1,6 @@
 import { Server } from '@hapi/hapi';
 import * as Handlers from './item.handlers';
+import Joi from 'joi';
 
 export const defineRoutes = (server: Server) => {
     server.route({
@@ -16,5 +17,24 @@ export const defineRoutes = (server: Server) => {
         method: 'GET',
         path: '/items',
         handler: Handlers.getItems,
+    });
+
+    server.route({
+        method: 'GET',
+        path: '/items/{id}',
+        options: {
+            validate: {
+                params: Joi.object({
+                    id: Joi.number().integer().positive().required(),
+                }),
+                failAction: (request, h, err: any) => {
+                    return h
+                        .response({ error: err.message })
+                        .code(400)
+                        .takeover();
+                },
+            },
+        },
+        handler: Handlers.getItemById,
     });
 };

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -80,4 +80,23 @@ export const defineRoutes = (server: Server) => {
         },
         handler: Handlers.updateItem,
     });
+
+    server.route({
+        method: 'DELETE',
+        path: '/items/{id}',
+        options: {
+            validate: {
+                params: Joi.object({
+                    id: Joi.number().integer().positive().required(),
+                }),
+                failAction: (request, h, err: any) => {
+                    return h
+                        .response({ error: err.message })
+                        .code(400)
+                        .takeover();
+                },
+            },
+        },
+        handler: Handlers.deleteItem,
+    });
 };

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -57,4 +57,27 @@ export const defineRoutes = (server: Server) => {
         },
         handler: Handlers.createItem,
     });
+
+    server.route({
+        method: 'PUT',
+        path: '/items/{id}',
+        options: {
+            validate: {
+                params: Joi.object({
+                    id: Joi.number().integer().positive().required(),
+                }),
+                payload: Joi.object({
+                    name: Joi.string().min(1).required(),
+                    price: Joi.number().positive().required(),
+                }),
+                failAction: (request, h, err) => {
+                    return h
+                        .response({ error: err?.message ?? 'Invalid request' })
+                        .code(400)
+                        .takeover();
+                },
+            },
+        },
+        handler: Handlers.updateItem,
+    });
 };


### PR DESCRIPTION
## Summary
This PR adds all RESTful API endpoints for the `Item` entity using Hapi, along with input validation using Joi and a clean separation of route handlers.

## Changes
- Installed `joi` for request validation
- Created `src/handlers/item.handlers.ts` to hold route handler logic
- Implemented and registered the following endpoints:
  - `GET /items` — list all items
  - `GET /items/{id}` — get item by ID (with validation)
  - `POST /items` — create new item (with validation)
  - `PUT /items/{id}` — update existing item (with validation)
  - `DELETE /items/{id}` — delete item by ID (with validation)

## Motivation
Provides a complete and validated API interface for interacting with `Item` entities, following clean architecture and separation of concerns.

## Checklist
- [x] Handlers extracted into `item.handlers.ts`
- [x] All CRUD endpoints implemented
- [x] Input validation with Joi added
- [x] Clean commit history for each route
