### PR TITLE
docs: update README with API testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,3 +117,17 @@ Make sure you have Docker and the **Dev Containers** extension installed.
 -   `GET /items/{id}` – Get item by ID
 -   `PUT /items/{id}` – Update an item
 -   `DELETE /items/{id}` – Delete an item
+
+### API Testing
+
+To test the API endpoints, you can use the [REST Client extension](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) in VS Code.
+
+Example requests are located [docs/requests.http](docs/requests.http)
+
+Ensure the service is running locally before sending any requests:
+
+```bash
+npm run dev
+```
+
+This setup allows you to quickly test all endpoints directly within your editor.

--- a/docs/requests.http
+++ b/docs/requests.http
@@ -1,0 +1,43 @@
+### GET ping
+GET http://localhost:3000/ping
+Accept: application/json
+
+###
+
+### GET all items
+GET http://localhost:3000/items
+Accept: application/json
+
+###
+
+### POST create new item
+POST http://localhost:3000/items
+Content-Type: application/json
+
+{
+  "name": "Test Item",
+  "price": 100
+}
+
+###
+
+### GET item by ID
+GET http://localhost:3000/items/1
+Accept: application/json
+
+###
+
+### PUT update item
+PUT http://localhost:3000/items/1
+Content-Type: application/json
+
+{
+  "name": "Updated Item",
+  "price": 150
+}
+
+###
+
+### DELETE item
+DELETE http://localhost:3000/items/1
+Accept: application/json


### PR DESCRIPTION
## Summary
This PR enhances the project README by adding a section for API testing instructions.

## Changes
- Added 🧪 API Testing section with guidance on using REST Client
- Linked to docs/requests.http for sample request examples

## Motivation
Provides clearer context for contributors and interviewers by making it easier to test the API locally.

## Checklist
- [x] REST Client instructions added
- [x] Link to example requests file included